### PR TITLE
Optimizations

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,175 +1,207 @@
 # Benchmark results without schema evolution
 
-This benchmark serializes/deserializes 10000 "oplog entries", where oplog entries is a big enum type, 
+This benchmark serializes/deserializes 10000 "oplog entries", where oplog entries is a big enum type,
 taken from an early prototype of [Golem](https://github.com/golemcloud/golem). Some of the cases have
-an arbitrary byte array payload in them, which the benchmark sets to various sizes to see the effect on
+an arbitrary dynamic 'Value' payloads in them, which the benchmark sets to various sizes to see the effect on
 serialization speed.
 
+Generating data set
 ## Benchmarking case with 10000 entries, payload size 16 bytes
 
+...JSON...
+...bincode...
+...bincode without serde...
+...MessagePack (rmp-serde)...
+...postcard...
+...BARE...
+...bitcode...
+...desert...
 JSON
-- total size:               18270410 bytes
-- serialization duration:   3.534995ms
-- deserialization duration: 5.546094ms
+- total size:               21897680 bytes
+- serialization duration:   2.419896ms
+- deserialization duration: 3.874654ms
 
 bincode
-- total size:               3992850 bytes
-- serialization duration:   1.890258ms
-- deserialization duration: 1.152444ms
+- total size:               4523670 bytes
+- serialization duration:   1.143416ms
+- deserialization duration: 848.595µs
 
 bincode without serde
-- total size:               3992410 bytes
-- serialization duration:   1.273413ms
-- deserialization duration: 840.346µs
+- total size:               4523230 bytes
+- serialization duration:   693.162µs
+- deserialization duration: 712.804µs
 
 MessagePack (rmp-serde)
-- total size:               6860700 bytes
-- serialization duration:   1.461062ms
-- deserialization duration: 2.929389ms
-  
+- total size:               8954490 bytes
+- serialization duration:   2.471866ms
+- deserialization duration: 2.001346ms
+
 postcard
-- total size:               3723940 bytes
-- serialization duration:   699.054µs
-- deserialization duration: 861.619µs
-  
+- total size:               4254760 bytes
+- serialization duration:   436.383µs
+- deserialization duration: 709.345µs
+
 BARE
-- total size:               3850700 bytes
-- serialization duration:   858.038µs
-- deserialization duration: 1.554844ms
+- total size:               4381520 bytes
+- serialization duration:   600.162µs
+- deserialization duration: 1.296845ms
 
 bitcode
-- total size:               4092090 bytes
-- serialization duration:   8.064358ms
-- deserialization duration: 6.0171ms
+- total size:               4239540 bytes
+- serialization duration:   5.02062ms
+- deserialization duration: 6.345041ms
 
 **desert**
-- total size:               4164660 bytes
-- serialization duration:   2.338951ms
-- deserialization duration: 3.013326ms 
- 
+- total size:               5196810 bytes
+- serialization duration:   1.075125ms
+- deserialization duration: 1.171066ms
+
 ## Benchmarking case with 10000 entries, payload size 256 bytes
 
+...JSON...
+...bincode...
+...bincode without serde...
+...MessagePack (rmp-serde)...
+...postcard...
+...BARE...
+...bitcode...
+...desert...
 JSON
-- total size:               79051770 bytes
-- serialization duration:   21.282349ms
-- deserialization duration: 31.889273ms
+- total size:               130653630 bytes
+- serialization duration:   14.857854ms
+- deserialization duration: 30.555216ms
 
 bincode
-- total size:               21156090 bytes
-- serialization duration:   5.358322ms
-- deserialization duration: 4.496157ms
+- total size:               28540050 bytes
+- serialization duration:   3.866045ms
+- deserialization duration: 5.976562ms
 
 bincode without serde
-- total size:               21155890 bytes
-- serialization duration:   1.485321ms
-- deserialization duration: 1.062149ms
+- total size:               28539850 bytes
+- serialization duration:   3.343825ms
+- deserialization duration: 3.853312ms
 
 MessagePack (rmp-serde)
-- total size:               32373110 bytes
-- serialization duration:   12.363401ms
-- deserialization duration: 17.009083ms
+- total size:               61880330 bytes
+- serialization duration:   15.699295ms
+- deserialization duration: 18.298858ms
 
 postcard
-- total size:               20817410 bytes
-- serialization duration:   4.762567ms
-- deserialization duration: 3.42866ms
+- total size:               28201370 bytes
+- serialization duration:   2.794162ms
+- deserialization duration: 3.494741ms
 
 BARE
-- total size:               20942730 bytes
-- serialization duration:   6.417973ms
-- deserialization duration: 11.144555ms
+- total size:               28326690 bytes
+- serialization duration:   5.386591ms
+- deserialization duration: 9.593004ms
 
 bitcode
-- total size:               21326510 bytes
-- serialization duration:   10.377369ms
-- deserialization duration: 8.463068ms 
+- total size:               22328210 bytes
+- serialization duration:   8.83335ms
+- deserialization duration: 9.648112ms
 
 **desert**
-- total size:               21257490 bytes
-- serialization duration:   3.684346ms
-- deserialization duration: 3.659971ms
-  
+- total size:               35996790 bytes
+- serialization duration:   6.6763ms
+- deserialization duration: 5.822154ms
 
 ## Benchmarking case with 10000 entries, payload size 1024 bytes
-  
+
+...JSON...
+...bincode...
+...bincode without serde...
+...MessagePack (rmp-serde)...
+...postcard...
+...BARE...
+...bitcode...
+...desert...
 JSON
-- total size:               275904820 bytes
-- serialization duration:   66.386483ms
-- deserialization duration: 102.119753ms
+- total size:               480290950 bytes
+- serialization duration:   53.205616ms
+- deserialization duration: 109.613875ms
 
 bincode
-- total size:               76298500 bytes
-- serialization duration:   12.598484ms
-- deserialization duration: 14.708719ms
-
-bincode without serde (current implementation)
-- total size:               76298100 bytes
-- serialization duration:   3.110397ms
-- deserialization duration: 2.029679ms
-
-MessagePack (rmp-serde)
-- total size:               115077580 bytes
-- serialization duration:   46.694929ms
-- deserialization duration: 63.136818ms
-
-postcard
-- total size:               75958900 bytes
-- serialization duration:   15.382506ms
-- deserialization duration: 12.341794ms
-
-BARE
-- total size:               76084840 bytes
-- serialization duration:   21.800745ms
-- deserialization duration: 35.825761ms
-
-bitcode
-- total size:               76469580 bytes
-- serialization duration:   18.171212ms
-- deserialization duration: 16.978511ms
-  
-**desert**
-- total size:               76400160 bytes
-- serialization duration:   5.10305ms
-- deserialization duration: 4.503051ms
-  
-## Benchmarking case with 10000 entries, payload size 16384 bytes
-
-JSON
-- total size:               4224183380 bytes
-- serialization duration:   1.082191248s
-- deserialization duration: 1.611288103s
-
-bincode
-- total size:               1182149070 bytes
-- serialization duration:   138.413387ms
-- deserialization duration: 227.466057ms
+- total size:               105508720 bytes
+- serialization duration:   10.722729ms
+- deserialization duration: 22.111728ms
 
 bincode without serde
-- total size:               1182148750 bytes
-- serialization duration:   20.931162ms
-- deserialization duration: 18.64979ms
+- total size:               105508320 bytes
+- serialization duration:   11.654062ms
+- deserialization duration: 14.060412ms
 
 MessagePack (rmp-serde)
-- total size:               1773910600 bytes
-- serialization duration:   738.76901ms
-- deserialization duration: 981.761867ms 
+- total size:               231889990 bytes
+- serialization duration:   55.562737ms
+- deserialization duration: 70.155358ms
 
 postcard
-- total size:               1181881650 bytes
-- serialization duration:   200.451978ms
-- deserialization duration: 201.557102ms
+- total size:               105169120 bytes
+- serialization duration:   9.322028ms
+- deserialization duration: 12.22675ms
 
 BARE
-- total size:               1182006410 bytes
-- serialization duration:   361.714387ms
-- deserialization duration: 524.595809ms
+- total size:               105295060 bytes
+- serialization duration:   20.050962ms
+- deserialization duration: 34.204704ms
 
 bitcode
-- total size:               1182321010 bytes
-- serialization duration:   145.3623ms
-- deserialization duration: 190.639901ms
+- total size:               80199150 bytes
+- serialization duration:   18.484208ms
+- deserialization duration: 19.140212ms
 
 **desert**
-- total size:               1182320640 bytes
-- serialization duration:   22.305921ms
-- deserialization duration: 19.189082ms
+- total size:               134792130 bytes
+- serialization duration:   23.074337ms
+- deserialization duration: 20.605966ms
+
+## Benchmarking case with 10000 entries, payload size 16384 bytes
+
+...JSON...
+...bincode...
+...bincode without serde...
+...MessagePack (rmp-serde)...
+...postcard...
+...BARE...
+...bitcode...
+...desert...
+JSON
+- total size:               7582570100 bytes
+- serialization duration:   796.629195ms
+- deserialization duration: 1.714430683s
+
+bincode
+- total size:               1661931150 bytes
+- serialization duration:   141.912479ms
+- deserialization duration: 340.191175ms
+
+bincode without serde
+- total size:               1661930830 bytes
+- serialization duration:   176.784912ms
+- deserialization duration: 210.847895ms
+
+MessagePack (rmp-serde)
+- total size:               3693009640 bytes
+- serialization duration:   843.058737ms
+- deserialization duration: 1.108289866s
+
+postcard
+- total size:               1661663730 bytes
+- serialization duration:   125.145387ms
+- deserialization duration: 187.903329ms
+
+BARE
+- total size:               1661788490 bytes
+- serialization duration:   296.375849ms
+- deserialization duration: 513.484474ms
+
+bitcode
+- total size:               1242374290 bytes
+- serialization duration:   203.318737ms
+- deserialization duration: 206.068116ms
+
+**desert**
+- total size:               2141855520 bytes
+- serialization duration:   361.245366ms
+- deserialization duration: 312.288645ms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
 
 [workspace.dependencies]
 test-r = "2.3.1"
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
 [workspace.dependencies]
 test-r = "2.3.1"
 
-[profile.release]
-debug = true
+# Enable when profiling
+#[profile.release]
+#debug = true

--- a/desert_benchmarks/Cargo.toml
+++ b/desert_benchmarks/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.228"
 serde_bare = { version = "0.5.0", features = ["std"] }
 serde_json = "1.0.145"
 serde_yaml = "0.9.34"
-uuid = { version="1.18.1", features = ["serde", "v4"] }
+uuid = { version = "1.18.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/desert_benchmarks/src/main.rs
+++ b/desert_benchmarks/src/main.rs
@@ -254,7 +254,7 @@ fn main() {
     println!();
     println!("This benchmark serializes/deserializes 10000 \"oplog entries\", where oplog entries is a big enum type,");
     println!("taken from an early prototype of [Golem](https://github.com/golemcloud/golem). Some of the cases have");
-    println!("an arbitrary byte array payload in them, which the benchmark sets to various sizes to see the effect on");
+    println!("an arbitrary dynamic 'Value' payload in them, which the benchmark sets to various sizes to see the effect on");
     println!("serialization speed.");
     println!();
 

--- a/desert_benchmarks/src/model.rs
+++ b/desert_benchmarks/src/model.rs
@@ -291,9 +291,7 @@ pub fn random_oplog_entry(rng: &mut impl Rng, payload_size: usize) -> OplogEntry
                     .take(16)
                     .map(char::from)
                     .collect(),
-                request: vec![Value::List(
-                    request.into_iter().map(|b| Value::U8(b)).collect(),
-                )],
+                request: vec![Value::List(request.into_iter().map(Value::U8).collect())],
                 invocation_key: random_invocation_key(rng),
                 calling_convention: random_calling_convention(rng),
             }
@@ -304,9 +302,7 @@ pub fn random_oplog_entry(rng: &mut impl Rng, payload_size: usize) -> OplogEntry
 
             OplogEntry::ExportedFunctionCompleted {
                 timestamp: random_timestamp(rng),
-                response: vec![Value::List(
-                    response.into_iter().map(|b| Value::U8(b)).collect(),
-                )],
+                response: vec![Value::List(response.into_iter().map(Value::U8).collect())],
                 consumed_fuel: rng.random(),
             }
         }

--- a/desert_core/src/adt/deserializer.rs
+++ b/desert_core/src/adt/deserializer.rs
@@ -6,19 +6,19 @@ use crate::deserializer::InputRegion;
 use crate::evolution::SerializedEvolutionStep;
 use crate::{BinaryDeserializer, BinaryInput, DeserializationContext, Error, Result};
 
-pub struct AdtDeserializer<'a, 'b, 'c> {
+pub struct AdtDeserializer<'a, 'b, 'c, const V: usize> {
     metadata: &'a AdtMetadata,
     context: &'b mut DeserializationContext<'c>,
-    last_index_per_chunk: Vec<i8>,
+    last_index_per_chunk: Option<[i8; V]>,
     read_constructor_idx: Option<u32>,
 
     stored_version: u8,
-    made_optional_at: BTreeMap<FieldPosition, u8>,
-    removed_fields: HashSet<String>,
-    inputs: Vec<InputRegion>,
+    made_optional_at: Option<BTreeMap<FieldPosition, u8>>,
+    removed_fields: Option<HashSet<String>>,
+    inputs: Option<Vec<InputRegion>>,
 }
 
-impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
+impl<'a, 'b, 'c, const V: usize> AdtDeserializer<'a, 'b, 'c, V> {
     pub fn new_v0(
         metadata: &'a AdtMetadata,
         context: &'b mut DeserializationContext<'c>,
@@ -26,12 +26,12 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
         Ok(Self {
             metadata,
             context,
-            last_index_per_chunk: vec![-1i8; metadata.version as usize + 1],
+            last_index_per_chunk: None,
             read_constructor_idx: None,
             stored_version: 0,
-            made_optional_at: BTreeMap::new(),
-            removed_fields: HashSet::new(),
-            inputs: Vec::new(),
+            made_optional_at: None,
+            removed_fields: None,
+            inputs: None,
         })
     }
 
@@ -74,12 +74,28 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
         Ok(Self {
             metadata,
             context,
-            last_index_per_chunk: vec![-1i8; metadata.version as usize + 1],
+            last_index_per_chunk: if made_optional_at.is_empty() {
+                None
+            } else {
+                Some([-1i8; V])
+            },
             read_constructor_idx: None,
             stored_version,
-            made_optional_at,
-            removed_fields,
-            inputs,
+            made_optional_at: if made_optional_at.is_empty() {
+                None
+            } else {
+                Some(made_optional_at)
+            },
+            removed_fields: if removed_fields.is_empty() {
+                None
+            } else {
+                Some(removed_fields)
+            },
+            inputs: if inputs.is_empty() {
+                None
+            } else {
+                Some(inputs)
+            },
         })
     }
 
@@ -88,7 +104,12 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
         field_name: &str,
         field_default: Option<T>,
     ) -> Result<T> {
-        if self.removed_fields.contains(field_name) {
+        if self
+            .removed_fields
+            .as_ref()
+            .map(|f| f.contains(field_name))
+            .unwrap_or(false)
+        {
             Err(Error::FieldRemovedInSerializedVersion(
                 field_name.to_string(),
             ))
@@ -110,11 +131,17 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
             } else {
                 // Field was serialized
 
-                let has_inputs = !self.inputs.is_empty();
-                if has_inputs {
-                    self.context.push_region(self.inputs[chunk as usize]);
+                let mut has_inputs = false;
+                if let Some(inputs) = self.inputs.as_mut() {
+                    self.context.push_region(inputs[chunk as usize]);
+                    has_inputs = true;
                 }
-                let result = if self.made_optional_at.contains_key(&field_position) {
+                let result = if self
+                    .made_optional_at
+                    .as_ref()
+                    .map(|m| m.contains_key(&field_position))
+                    .unwrap_or(false)
+                {
                     // The field was made optional in a newer version, so we have to read Option<T>
 
                     let is_defined = bool::deserialize(self.context)?;
@@ -129,7 +156,7 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
                     T::deserialize(self.context)
                 };
                 if has_inputs {
-                    self.inputs[chunk as usize] = self.context.pop_region();
+                    self.inputs.as_mut().unwrap()[chunk as usize] = self.context.pop_region();
                 }
                 result
             }
@@ -141,7 +168,12 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
         field_name: &str,
         field_default: Option<Option<T>>,
     ) -> Result<Option<T>> {
-        if self.removed_fields.contains(field_name) {
+        if self
+            .removed_fields
+            .as_ref()
+            .map(|f| f.contains(field_name))
+            .unwrap_or(false)
+        {
             Ok(None)
         } else {
             let chunk = *self
@@ -163,9 +195,10 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
             } else {
                 // This field was serialized
 
-                let has_inputs = !self.inputs.is_empty();
-                if has_inputs {
-                    self.context.push_region(self.inputs[chunk as usize]);
+                let mut has_inputs = false;
+                if let Some(inputs) = self.inputs.as_mut() {
+                    self.context.push_region(inputs[chunk as usize]);
+                    has_inputs = true;
                 }
                 let result = if self.stored_version < opt_since {
                     Ok(Some(T::deserialize(self.context)?))
@@ -173,7 +206,7 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
                     Option::<T>::deserialize(self.context)
                 };
                 if has_inputs {
-                    self.inputs[chunk as usize] = self.context.pop_region();
+                    self.inputs.as_mut().unwrap()[chunk as usize] = self.context.pop_region();
                 }
                 result
             }
@@ -187,40 +220,31 @@ impl<'a, 'b, 'c> AdtDeserializer<'a, 'b, 'c> {
     ) -> Result<Option<T>> {
         let constructor_idx = self.read_or_get_constructor_idx()?;
         if constructor_idx == case_idx {
-            let has_inputs = !self.inputs.is_empty();
-            if has_inputs {
-                self.context.push_region(self.inputs[0]);
-            }
-            let result = Ok(Some(deserialize_case(self.context)?));
-            if has_inputs {
-                self.inputs[0] = self.context.pop_region();
-            }
-            result
+            Ok(Some(deserialize_case(self.context)?))
         } else {
             Ok(None)
         }
     }
 
     fn record_field_index(&mut self, chunk: u8) -> FieldPosition {
-        let last_index = &mut self.last_index_per_chunk[chunk as usize];
-        let new_index = *last_index + 1;
-        let fp = FieldPosition::new(chunk, new_index as u8);
-        *last_index = new_index;
-        fp
+        if let Some(last_index_per_chunk) = self.last_index_per_chunk.as_mut() {
+            // We only need to track this information when we have made_optional_at information
+
+            let last_index = &mut last_index_per_chunk.as_mut()[chunk as usize];
+            let new_index = *last_index + 1;
+            let fp = FieldPosition::new(chunk, new_index as u8);
+            *last_index = new_index;
+            fp
+        } else {
+            FieldPosition::EMPTY
+        }
     }
 
     pub fn read_or_get_constructor_idx(&mut self) -> Result<u32> {
         match self.read_constructor_idx {
             Some(idx) => Ok(idx),
             None => {
-                let has_inputs = !self.inputs.is_empty();
-                if has_inputs {
-                    self.context.push_region(self.inputs[0]);
-                }
                 let constructor_idx = self.context.read_var_u32()?;
-                if has_inputs {
-                    self.inputs[0] = self.context.pop_region();
-                }
                 self.read_constructor_idx = Some(constructor_idx);
                 Ok(constructor_idx)
             }

--- a/desert_core/src/adt/mod.rs
+++ b/desert_core/src/adt/mod.rs
@@ -84,7 +84,10 @@ pub struct FieldPosition {
 }
 
 impl FieldPosition {
-    const EMPTY: Self = FieldPosition { chunk: 0, position: 0 };
+    const EMPTY: Self = FieldPosition {
+        chunk: 0,
+        position: 0,
+    };
 
     pub fn new(chunk: u8, position: u8) -> Self {
         Self { chunk, position }

--- a/desert_core/src/adt/mod.rs
+++ b/desert_core/src/adt/mod.rs
@@ -84,6 +84,8 @@ pub struct FieldPosition {
 }
 
 impl FieldPosition {
+    const EMPTY: Self = FieldPosition { chunk: 0, position: 0 };
+
     pub fn new(chunk: u8, position: u8) -> Self {
         Self { chunk, position }
     }

--- a/desert_core/src/adt/serializer.rs
+++ b/desert_core/src/adt/serializer.rs
@@ -98,16 +98,13 @@ impl<'a, 'b, Output: BinaryOutput, const V: usize> AdtSerializer<'a, 'b, Output,
 
     fn record_field_index(&mut self, field_name: &str, chunk: u8) {
         if let Some(last_index_per_chunk) = self.last_index_per_chunk.as_mut() {
-            match &mut last_index_per_chunk[chunk as usize] {
-                last_index => {
-                    let new_index = *last_index + 1;
-                    *last_index = new_index;
-                    self.field_indices.as_mut().unwrap().insert(
-                        field_name.to_string(),
-                        FieldPosition::new(chunk, new_index as u8),
-                    );
-                }
-            }
+            let last_index = &mut last_index_per_chunk[chunk as usize];
+            let new_index = *last_index + 1;
+            *last_index = new_index;
+            self.field_indices.as_mut().unwrap().insert(
+                field_name.to_string(),
+                FieldPosition::new(chunk, new_index as u8),
+            );
         }
     }
 

--- a/desert_core/src/adt/serializer.rs
+++ b/desert_core/src/adt/serializer.rs
@@ -1,4 +1,5 @@
 use hashbrown::{HashMap, HashSet};
+use std::array;
 
 use crate::adt::{AdtMetadata, FieldPosition};
 use crate::evolution::SerializedEvolutionStep;
@@ -7,15 +8,15 @@ use crate::{
     DEFAULT_CAPACITY,
 };
 
-pub struct AdtSerializer<'a, 'b, Output: BinaryOutput> {
+pub struct AdtSerializer<'a, 'b, Output: BinaryOutput, const V: usize> {
     metadata: &'a AdtMetadata,
     context: &'b mut SerializationContext<Output>,
-    buffers: Vec<Option<Vec<u8>>>, // TODO: We can avoid this completely by generating the write_fields in the proper order
-    last_index_per_chunk: HashMap<u8, u8>,
-    field_indices: HashMap<String, FieldPosition>,
+    buffers: Option<[Option<Vec<u8>>; V]>,
+    last_index_per_chunk: Option<[i8; V]>,
+    field_indices: Option<HashMap<String, FieldPosition>>,
 }
 
-impl<'a, 'b, Output: BinaryOutput> AdtSerializer<'a, 'b, Output> {
+impl<'a, 'b, Output: BinaryOutput, const V: usize> AdtSerializer<'a, 'b, Output, V> {
     pub fn new_v0(
         metadata: &'a AdtMetadata,
         context: &'b mut SerializationContext<Output>,
@@ -25,22 +26,31 @@ impl<'a, 'b, Output: BinaryOutput> AdtSerializer<'a, 'b, Output> {
         Self {
             metadata,
             context,
-            buffers: Vec::new(),
-            last_index_per_chunk: HashMap::new(),
-            field_indices: HashMap::new(),
+            buffers: None,
+            last_index_per_chunk: None,
+            field_indices: None,
         }
     }
 
     pub fn new(metadata: &'a AdtMetadata, context: &'b mut SerializationContext<Output>) -> Self {
         context.write_u8(metadata.version);
+        let contains_field_made_optional = !metadata.made_optional_at.is_empty();
         Self {
             metadata,
             context,
-            buffers: (0..=metadata.version)
-                .map(|_| Some(Vec::with_capacity(DEFAULT_CAPACITY)))
-                .collect(),
-            last_index_per_chunk: HashMap::new(),
-            field_indices: HashMap::new(),
+            buffers: Some(array::from_fn(|_| {
+                Some(Vec::with_capacity(DEFAULT_CAPACITY))
+            })),
+            last_index_per_chunk: if contains_field_made_optional {
+                Some([-1; V])
+            } else {
+                None
+            },
+            field_indices: if contains_field_made_optional {
+                Some(HashMap::new())
+            } else {
+                None
+            },
         }
     }
 
@@ -50,26 +60,28 @@ impl<'a, 'b, Output: BinaryOutput> AdtSerializer<'a, 'b, Output> {
             .field_generations
             .get(field_name)
             .unwrap_or(&0);
-        let requires_buffer = !self.buffers.is_empty();
-        if requires_buffer {
+        let mut requires_buffer = false;
+        if let Some(buffers) = self.buffers.as_mut() {
             self.context
-                .push_buffer(self.buffers[chunk as usize].take().unwrap());
+                .push_buffer(buffers[chunk as usize].take().unwrap());
+            requires_buffer = true;
         }
         value.serialize(self.context)?;
         if requires_buffer {
-            self.buffers[chunk as usize] = Some(self.context.pop_buffer());
+            self.buffers.as_mut().unwrap()[chunk as usize] = Some(self.context.pop_buffer());
             self.record_field_index(field_name, chunk);
         }
         Ok(())
     }
 
     pub fn finish(mut self) -> Result<()> {
-        if !self.buffers.is_empty() {
+        if let Some(buffers) = self.buffers.take() {
             self.write_evolution_header(
+                &buffers,
                 &self.metadata.evolution_steps,
                 &self.metadata.removed_fields,
             )?;
-            self.write_ordered_chunks()
+            self.write_ordered_chunks(buffers)
         } else {
             Ok(())
         }
@@ -85,50 +97,52 @@ impl<'a, 'b, Output: BinaryOutput> AdtSerializer<'a, 'b, Output> {
     }
 
     fn record_field_index(&mut self, field_name: &str, chunk: u8) {
-        match self.last_index_per_chunk.get_mut(&chunk) {
-            Some(last_index) => {
-                let new_index = *last_index + 1;
-                *last_index = new_index;
-                self.field_indices
-                    .insert(field_name.to_string(), FieldPosition::new(chunk, new_index));
-            }
-            None => {
-                self.last_index_per_chunk.insert(chunk, 0);
-                self.field_indices
-                    .insert(field_name.to_string(), FieldPosition::new(chunk, 0));
+        if let Some(last_index_per_chunk) = self.last_index_per_chunk.as_mut() {
+            match &mut last_index_per_chunk[chunk as usize] {
+                last_index => {
+                    let new_index = *last_index + 1;
+                    *last_index = new_index;
+                    self.field_indices.as_mut().unwrap().insert(
+                        field_name.to_string(),
+                        FieldPosition::new(chunk, new_index as u8),
+                    );
+                }
             }
         }
     }
 
     fn write_evolution_header(
         &mut self,
+        buffers: &[Option<Vec<u8>>],
         evolution_steps: &[Evolution],
         removed_fields: &HashSet<String>,
     ) -> Result<()> {
         for (v, evolution) in evolution_steps.iter().enumerate() {
             let step = match evolution {
                 Evolution::InitialVersion => {
-                    let size = self.buffers[v].as_ref().unwrap().len().try_into()?;
+                    let size = buffers[v].as_ref().unwrap().len().try_into()?;
                     Ok(SerializedEvolutionStep::FieldAddedToNewChunk { size })
                 }
                 Evolution::FieldAdded { .. } => {
-                    let size = self.buffers[v].as_ref().unwrap().len().try_into()?;
+                    let size = buffers[v].as_ref().unwrap().len().try_into()?;
                     Ok(SerializedEvolutionStep::FieldAddedToNewChunk { size })
                 }
-                Evolution::FieldMadeOptional { name } => match self.field_indices.get(name) {
-                    Some(field_position) => Ok(SerializedEvolutionStep::FieldMadeOptional {
-                        position: *field_position,
-                    }),
-                    None => {
-                        if removed_fields.contains(name) {
-                            Ok(SerializedEvolutionStep::FieldRemoved {
-                                field_name: name.clone(),
-                            })
-                        } else {
-                            Err(Error::UnknownFieldReferenceInEvolutionStep(name.clone()))
+                Evolution::FieldMadeOptional { name } => {
+                    match self.field_indices.as_ref().unwrap().get(name) {
+                        Some(field_position) => Ok(SerializedEvolutionStep::FieldMadeOptional {
+                            position: *field_position,
+                        }),
+                        None => {
+                            if removed_fields.contains(name) {
+                                Ok(SerializedEvolutionStep::FieldRemoved {
+                                    field_name: name.clone(),
+                                })
+                            } else {
+                                Err(Error::UnknownFieldReferenceInEvolutionStep(name.clone()))
+                            }
                         }
                     }
-                },
+                }
                 Evolution::FieldRemoved { name } => Ok(SerializedEvolutionStep::FieldRemoved {
                     field_name: name.clone(),
                 }),
@@ -143,9 +157,9 @@ impl<'a, 'b, Output: BinaryOutput> AdtSerializer<'a, 'b, Output> {
         Ok(())
     }
 
-    fn write_ordered_chunks(&mut self) -> Result<()> {
-        for buffer in &self.buffers {
-            self.context.write_bytes(buffer.as_ref().unwrap());
+    fn write_ordered_chunks(&mut self, buffers: [Option<Vec<u8>>; V]) -> Result<()> {
+        for buffer in buffers {
+            self.context.write_bytes(&buffer.unwrap());
         }
         Ok(())
     }

--- a/desert_core/src/binary_output.rs
+++ b/desert_core/src/binary_output.rs
@@ -116,10 +116,12 @@ impl BinaryOutput for BytesMut {
 }
 
 impl BinaryOutput for Vec<u8> {
+    #[inline(always)]
     fn write_u8(&mut self, value: u8) {
         self.push(value);
     }
 
+    #[inline(always)]
     fn write_bytes(&mut self, bytes: &[u8]) {
         self.extend_from_slice(bytes);
     }

--- a/desert_core/src/deserializer/tuples.rs
+++ b/desert_core/src/deserializer/tuples.rs
@@ -2,13 +2,13 @@ use crate::adt::{AdtDeserializer, EMPTY_ADT_METADATA};
 use crate::{BinaryDeserializer, BinaryInput, DeserializationContext};
 
 fn deserialize_tuple1<T1: BinaryDeserializer>(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1,)> {
     Ok((deserializer.read_field("_0", None)?,))
 }
 
 fn deserialize_tuple2<T1: BinaryDeserializer, T2: BinaryDeserializer>(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2)> {
     Ok((
         deserializer.read_field("_0", None)?,
@@ -17,7 +17,7 @@ fn deserialize_tuple2<T1: BinaryDeserializer, T2: BinaryDeserializer>(
 }
 
 fn deserialize_tuple3<T1: BinaryDeserializer, T2: BinaryDeserializer, T3: BinaryDeserializer>(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2, T3)> {
     Ok((
         deserializer.read_field("_0", None)?,
@@ -32,7 +32,7 @@ fn deserialize_tuple4<
     T3: BinaryDeserializer,
     T4: BinaryDeserializer,
 >(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2, T3, T4)> {
     Ok((
         deserializer.read_field("_0", None)?,
@@ -49,7 +49,7 @@ fn deserialize_tuple5<
     T4: BinaryDeserializer,
     T5: BinaryDeserializer,
 >(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2, T3, T4, T5)> {
     Ok((
         deserializer.read_field("_0", None)?,
@@ -68,7 +68,7 @@ fn deserialize_tuple6<
     T5: BinaryDeserializer,
     T6: BinaryDeserializer,
 >(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2, T3, T4, T5, T6)> {
     Ok((
         deserializer.read_field("_0", None)?,
@@ -89,7 +89,7 @@ fn deserialize_tuple7<
     T6: BinaryDeserializer,
     T7: BinaryDeserializer,
 >(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2, T3, T4, T5, T6, T7)> {
     Ok((
         deserializer.read_field("_0", None)?,
@@ -112,7 +112,7 @@ fn deserialize_tuple8<
     T7: BinaryDeserializer,
     T8: BinaryDeserializer,
 >(
-    deserializer: &mut AdtDeserializer,
+    deserializer: &mut AdtDeserializer<1>,
 ) -> crate::Result<(T1, T2, T3, T4, T5, T6, T7, T8)> {
     Ok((
         deserializer.read_field("_0", None)?,

--- a/desert_core/src/lib.rs
+++ b/desert_core/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod adt;
 mod binary_input;
 mod binary_output;
-mod deserializer;
+pub mod deserializer;
 mod error;
 mod evolution;
 mod features;
@@ -16,7 +16,7 @@ use std::fmt::{Display, Formatter};
 
 pub use binary_input::{BinaryInput, OwnedInput, SliceInput};
 pub use binary_output::{BinaryOutput, SizeCalculator};
-pub use deserializer::{BinaryDeserializer, DeserializationContext};
+pub use deserializer::{deserialize_iterator, BinaryDeserializer, DeserializationContext};
 pub use error::{Error, Result};
 pub use evolution::Evolution;
 pub use serializer::{serialize_iterator, BinarySerializer, SerializationContext};

--- a/desert_core/src/serializer/mod.rs
+++ b/desert_core/src/serializer/mod.rs
@@ -72,6 +72,7 @@ impl<Output: BinaryOutput> SerializationContext<Output> {
 }
 
 impl<Output: BinaryOutput> BinaryOutput for SerializationContext<Output> {
+    #[inline(always)]
     fn write_u8(&mut self, value: u8) {
         match self.buffer_stack.last_mut() {
             Some(buffer) => buffer.write_u8(value),
@@ -79,6 +80,7 @@ impl<Output: BinaryOutput> BinaryOutput for SerializationContext<Output> {
         }
     }
 
+    #[inline(always)]
     fn write_bytes(&mut self, bytes: &[u8]) {
         match self.buffer_stack.last_mut() {
             Some(buffer) => buffer.write_bytes(bytes),
@@ -103,6 +105,8 @@ pub enum StoreRefResult {
 }
 
 impl BinarySerializer for u8 {
+
+    #[inline(always)]
     fn serialize<Output: BinaryOutput>(
         &self,
         context: &mut SerializationContext<Output>,

--- a/desert_core/src/serializer/mod.rs
+++ b/desert_core/src/serializer/mod.rs
@@ -27,7 +27,7 @@ pub trait BinarySerializer {
 pub struct SerializationContext<Output: BinaryOutput> {
     output: Output,
     state: State,
-    buffer_stack: Vec<Vec<u8>>, // TODO: remove it once AdtSerializer does not need it anymore
+    buffer_stack: Vec<Vec<u8>>,
     options: Options,
 }
 
@@ -105,7 +105,6 @@ pub enum StoreRefResult {
 }
 
 impl BinarySerializer for u8 {
-
     #[inline(always)]
     fn serialize<Output: BinaryOutput>(
         &self,

--- a/desert_core/src/serializer/mod.rs
+++ b/desert_core/src/serializer/mod.rs
@@ -24,11 +24,16 @@ pub trait BinarySerializer {
     ) -> Result<()>;
 }
 
+pub enum BufferStack {
+    Direct,
+    Stacked { buffer_stack: Vec<Vec<u8>> },
+}
+
 pub struct SerializationContext<Output: BinaryOutput> {
     output: Output,
     state: State,
-    buffer_stack: Vec<Vec<u8>>,
     options: Options,
+    buffer_stack: BufferStack,
 }
 
 impl<Output: BinaryOutput> SerializationContext<Output> {
@@ -36,8 +41,8 @@ impl<Output: BinaryOutput> SerializationContext<Output> {
         Self {
             output,
             state: State::default(),
-            buffer_stack: Vec::new(),
             options,
+            buffer_stack: BufferStack::Direct,
         }
     }
 
@@ -62,29 +67,62 @@ impl<Output: BinaryOutput> SerializationContext<Output> {
         }
     }
 
+    pub fn options(&self) -> &Options {
+        &self.options
+    }
+
     pub fn push_buffer(&mut self, buffer: Vec<u8>) {
-        self.buffer_stack.push(buffer);
+        match &mut self.buffer_stack {
+            BufferStack::Direct => {
+                self.buffer_stack = BufferStack::Stacked {
+                    buffer_stack: vec![buffer],
+                };
+            }
+            BufferStack::Stacked { buffer_stack } => {
+                buffer_stack.push(buffer);
+            }
+        }
     }
 
     pub fn pop_buffer(&mut self) -> Vec<u8> {
-        self.buffer_stack.pop().unwrap()
+        match &mut self.buffer_stack {
+            BufferStack::Direct => {
+                panic!("pop_buffer called with no buffer on stack");
+            }
+            BufferStack::Stacked { buffer_stack } => {
+                let bytes = unsafe { buffer_stack.pop().unwrap_unchecked() };
+                if buffer_stack.is_empty() {
+                    self.buffer_stack = BufferStack::Direct;
+                }
+                bytes
+            }
+        }
     }
 }
 
 impl<Output: BinaryOutput> BinaryOutput for SerializationContext<Output> {
     #[inline(always)]
     fn write_u8(&mut self, value: u8) {
-        match self.buffer_stack.last_mut() {
-            Some(buffer) => buffer.write_u8(value),
-            None => self.output.write_u8(value),
+        match &mut self.buffer_stack {
+            BufferStack::Direct => self.output.write_u8(value),
+            BufferStack::Stacked { buffer_stack, .. } => {
+                unsafe { buffer_stack.last_mut().unwrap_unchecked().write_u8(value) };
+            }
         }
     }
 
     #[inline(always)]
     fn write_bytes(&mut self, bytes: &[u8]) {
-        match self.buffer_stack.last_mut() {
-            Some(buffer) => buffer.write_bytes(bytes),
-            None => self.output.write_bytes(bytes),
+        match &mut self.buffer_stack {
+            BufferStack::Direct => self.output.write_bytes(bytes),
+            BufferStack::Stacked { buffer_stack } => {
+                unsafe {
+                    buffer_stack
+                        .last_mut()
+                        .unwrap_unchecked()
+                        .write_bytes(bytes)
+                };
+            }
         }
     }
 }
@@ -377,7 +415,7 @@ impl BinarySerializer for char {
         &self,
         context: &mut SerializationContext<Output>,
     ) -> Result<()> {
-        if context.options.chars_as_u16 {
+        if context.options().chars_as_u16 {
             let mut buf = [0; 2];
             let result = self.encode_utf16(&mut buf);
             if result.len() == 1 {

--- a/desert_core/src/state.rs
+++ b/desert_core/src/state.rs
@@ -3,25 +3,38 @@ use crate::{RefId, StringId};
 use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
 use std::any::Any;
+use std::cell::OnceCell;
 
 #[derive(Default)]
-pub struct State {
+struct StringsState {
     strings_by_id: HashMap<StringId, String>,
     ids_by_string: HashMap<String, StringId>,
     last_string_id: StringId,
+}
+
+#[derive(Default)]
+struct RefsState {
     refs_by_id: HashMap<RefId, *const dyn Any>,
     ids_by_ref: HashMap<*const dyn Any, RefId>,
     last_ref_id: RefId,
 }
 
+#[derive(Default)]
+pub struct State {
+    strings: OnceCell<StringsState>,
+    refs: OnceCell<RefsState>,
+}
+
 impl State {
     pub fn store_string(&mut self, value: String) -> StoreStringResult {
-        match self.ids_by_string.entry(value) {
+        self.strings.get_or_init(|| StringsState::default());
+        let strings = unsafe { self.strings.get_mut().unwrap_unchecked() };
+        match strings.ids_by_string.entry(value) {
             Entry::Occupied(entry) => StoreStringResult::StringAlreadyStored { id: *entry.get() },
             Entry::Vacant(entry) => {
-                self.last_string_id.next();
-                let id = self.last_string_id;
-                self.strings_by_id.insert(id, entry.key().clone());
+                strings.last_string_id.next();
+                let id = strings.last_string_id;
+                strings.strings_by_id.insert(id, entry.key().clone());
                 let result = StoreStringResult::StringIsNew {
                     new_id: id,
                     value: entry.key().clone(),
@@ -33,12 +46,14 @@ impl State {
     }
 
     pub fn store_ref(&mut self, value: &impl Any) -> StoreRefResult {
-        match self.ids_by_ref.entry(value) {
+        self.refs.get_or_init(|| RefsState::default());
+        let refs = unsafe { self.refs.get_mut().unwrap_unchecked() };
+        match refs.ids_by_ref.entry(value) {
             Entry::Occupied(entry) => StoreRefResult::RefAlreadyStored { id: *entry.get() },
             Entry::Vacant(entry) => {
-                self.last_ref_id.next();
-                let id = self.last_ref_id;
-                self.refs_by_id.insert(id, value);
+                refs.last_ref_id.next();
+                let id = refs.last_ref_id;
+                refs.refs_by_id.insert(id, value);
                 let result = StoreRefResult::RefIsNew { new_id: id, value };
                 entry.insert(id);
                 result
@@ -47,11 +62,19 @@ impl State {
     }
 
     pub fn get_string_by_id(&self, id: StringId) -> Option<&str> {
-        self.strings_by_id.get(&id).map(|s| s.as_str())
+        self.strings
+            .get_or_init(|| StringsState::default())
+            .strings_by_id
+            .get(&id)
+            .map(|s| s.as_str())
     }
 
     pub fn get_ref_by_id(&self, id: RefId) -> Option<&dyn Any> {
-        let ptr = self.refs_by_id.get(&id);
+        let ptr = self
+            .refs
+            .get_or_init(|| RefsState::default())
+            .refs_by_id
+            .get(&id);
         match ptr {
             Some(ptr) => unsafe { ptr.as_ref() },
             None => None,

--- a/desert_core/src/state.rs
+++ b/desert_core/src/state.rs
@@ -27,7 +27,7 @@ pub struct State {
 
 impl State {
     pub fn store_string(&mut self, value: String) -> StoreStringResult {
-        self.strings.get_or_init(|| StringsState::default());
+        self.strings.get_or_init(StringsState::default);
         let strings = unsafe { self.strings.get_mut().unwrap_unchecked() };
         match strings.ids_by_string.entry(value) {
             Entry::Occupied(entry) => StoreStringResult::StringAlreadyStored { id: *entry.get() },
@@ -46,7 +46,7 @@ impl State {
     }
 
     pub fn store_ref(&mut self, value: &impl Any) -> StoreRefResult {
-        self.refs.get_or_init(|| RefsState::default());
+        self.refs.get_or_init(RefsState::default);
         let refs = unsafe { self.refs.get_mut().unwrap_unchecked() };
         match refs.ids_by_ref.entry(value) {
             Entry::Occupied(entry) => StoreRefResult::RefAlreadyStored { id: *entry.get() },
@@ -63,7 +63,7 @@ impl State {
 
     pub fn get_string_by_id(&self, id: StringId) -> Option<&str> {
         self.strings
-            .get_or_init(|| StringsState::default())
+            .get_or_init(StringsState::default)
             .strings_by_id
             .get(&id)
             .map(|s| s.as_str())
@@ -72,7 +72,7 @@ impl State {
     pub fn get_ref_by_id(&self, id: RefId) -> Option<&dyn Any> {
         let ptr = self
             .refs
-            .get_or_init(|| RefsState::default())
+            .get_or_init(RefsState::default)
             .refs_by_id
             .get(&id);
         match ptr {

--- a/desert_macro/src/lib.rs
+++ b/desert_macro/src/lib.rs
@@ -424,7 +424,7 @@ pub fn derive_binary_codec(input: TokenStream) -> TokenStream {
                                 serializer.write_constructor(
                                     #effective_case_idx,
                                     |desert_inner_serialization_context| {
-                                        let mut serializer = desert_rust::adt::AdtSerializer::#new_v(&#case_metadata_name, desert_inner_serialization_context);
+                                        let mut serializer = desert_rust::adt::AdtSerializer::<_, #vplus1>::#new_v(&#case_metadata_name, desert_inner_serialization_context);
                                         #(#case_serialization_commands)*
                                         serializer.finish()
                                     }
@@ -540,7 +540,7 @@ pub fn derive_binary_codec(input: TokenStream) -> TokenStream {
         #[allow(unused_variables)]
         impl #impl_generics desert_rust::BinarySerializer for #name #ty_generics #where_clause {
             fn serialize<Output: desert_rust::BinaryOutput>(&self, context: &mut desert_rust::SerializationContext<Output>) -> desert_rust::Result<()> {
-                let mut serializer = desert_rust::adt::AdtSerializer::#new_v(&#metadata_name, context);
+                let mut serializer = desert_rust::adt::AdtSerializer::<_, #vplus1>::#new_v(&#metadata_name, context);
                 #(#serialization_commands)*
                 serializer.finish()
             }


### PR DESCRIPTION
Various optimizations:
- reducing allocations in both the serialization and deserialization implementations, mostly in "non-evolved data type" cases
- ability to opt out from evolution support for single-field variant cases with `#[desert(transparent)]`
- ability to customize such variant cases with `#[desert(custom = Xyz)]` where `Xyz` is a wrapper type on the variant's field's `Cow` with a `BinaryCodec`
- updated the comparison benchmark to use a data structure from a more recent version of Golem (for investigating more real-world performance issues)
