### PR TITLE
Update nonempty-collections to 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty-collections"
-version = "0.3.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e216d0e8cf9d54fa66e5780f6e1d5dc96d1c1b3c25aeba3b6758548bcbbd8b9d"
+checksum = "3d127e00b37b19c36c28ac00e874240a61faeea14c7b759b1d9c77efa048322a"
 
 [[package]]
 name = "num-bigint"

--- a/desert_core/Cargo.toml
+++ b/desert_core/Cargo.toml
@@ -24,7 +24,7 @@ bit-vec = { version = "0.6", optional = true }
 chrono = { version = "0.4", optional = true }
 chrono-tz = { version = "0.10", optional = true }
 mac_address = { version = "1.1", optional = true }
-nonempty-collections = { version = "0.3.1", optional = true }
+nonempty-collections = { version = "1.2.1", optional = true }
 url = { version = "2.5", optional = true }
 uuid = { version = "1.18", optional = true }
 serde_json = { version = "1", optional = true }

--- a/desert_macro/src/lib.rs
+++ b/desert_macro/src/lib.rs
@@ -745,20 +745,16 @@ fn is_option(ty: &Type) -> bool {
     match ty {
         Type::Group(group) => is_option(&group.elem),
         Type::Paren(paren) => is_option(&paren.elem),
-        Type::Path(type_path) => {
-            if type_path.qself.is_none() {
-                let idents = type_path
-                    .path
-                    .segments
-                    .iter()
-                    .map(|segment| segment.ident.to_string())
-                    .collect::<Vec<_>>();
-                idents == vec!["Option"]
-                    || idents == vec!["std", "option", "Option"]
-                    || idents == vec!["core", "option", "Option"]
-            } else {
-                false
-            }
+        Type::Path(type_path) if type_path.qself.is_none() => {
+            let idents = type_path
+                .path
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>();
+            idents == vec!["Option"]
+                || idents == vec!["std", "option", "Option"]
+                || idents == vec!["core", "option", "Option"]
         }
         _ => false,
     }


### PR DESCRIPTION
Updates the optional nonempty-collections dependency from 0.3.1 to the 1.x line so downstream users can depend on the current nonempty-collections crate without a second alias.\n\nAlso adjusts one existing clippy warning in desert_macro so the documented clippy check remains green on the current toolchain.\n\nValidation run locally:\n- cargo build\n- cargo test\n- cargo clippy --no-deps --all-targets -- -Dwarnings